### PR TITLE
update circle and fix position key

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,21 +3,22 @@ machine:
     - docker
   environment:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
-    image_name: codeclimate-golint
-
-dependencies:
-  pre:
-    - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
-    - curl https://sdk.cloud.google.com | bash
-    - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
-    - gcloud docker -a
+    PRIVATE_REGISTRY: us.gcr.io/code_climate
 
 test:
   override:
-    - docker build -t=$registry_root/$image_name:b$CIRCLE_BUILD_NUM .
+    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
 
 deployment:
   registry:
     branch: master
     commands:
-      - docker push $registry_root/$image_name:b$CIRCLE_BUILD_NUM
+    - echo $gcloud_json_key_base64 | sed 's/ //g' | base64 -d > /tmp/gcloud_key.json
+    - curl https://sdk.cloud.google.com | bash
+    - gcloud auth activate-service-account $gcloud_account_email --key-file /tmp/gcloud_key.json
+    - gcloud docker -a
+    - docker push $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM
+
+notify:
+  webhooks:
+    - url: https://cc-slack-proxy.herokuapp.com/circle

--- a/codeclimate-golint.go
+++ b/codeclimate-golint.go
@@ -42,7 +42,7 @@ func main() {
 				Description: "Could not read file",
 				Location: &engine.Location{
 					Path: path,
-					Lines: &engine.Position{
+					Lines: &engine.LinesOnlyPosition{
 						Begin: 1,
 						End:   1,
 					},
@@ -97,7 +97,7 @@ func codeClimateLocation(l *lint.Problem, path string, rootPath string) *engine.
 
 	return &engine.Location{
 		Path: strings.SplitAfter(path, rootPath)[1],
-		Lines: &engine.Position{
+		Lines: &engine.LinesOnlyPosition{
 			Begin: position.Line,
 			End:   position.Line,
 		},


### PR DESCRIPTION
Update `circle.yml` so that forked PRs can pass, following example in [codeclimate-fixme]().

Original goal was to be able to have CI build pass on [this PR](https://github.com/codeclimate-community/codeclimate-golint/pull/3/files). The CI build - in a catch 22 of sorts - doesn't pass without the fix in that PR though, so I've added it here as well.

@codeclimate/review @jacobi007 