### PR TITLE
Cleanup & support for minimum confidence threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ Golint is a linter for Go code. Where as [Gofmt](https://www.github.com/codeclim
 2. Run `codeclimate engines:enable golint`. This command both installs the engine and enables it in your `.codeclimate.yml` file.
 3. You're ready to analyze! Browse into your project's folder and run `codeclimate analyze`.
 
+### Configuration
+
+Like the `golint` binary, you can configure the minimum confidence threshold of
+this engine: issues reported by `golint` must have a confidence value higher than
+the threshold in order to be reported. The default value is `0.8`, the same as
+`golint`: you can configure your own threshold in your `.codeclimate.yml`:
+
+```yaml
+engines:
+  golint:
+    enabled: true
+    config:
+      min_confidence: 0.1
+```
+
 ### Building
 
 In order to build the docker image, you first need to compile a binary for the container. To do that, first [install goxc]() and then run

--- a/codeclimate-golint.go
+++ b/codeclimate-golint.go
@@ -87,7 +87,7 @@ func lintFile(fullPath string, relativePath string) {
 			Type:              "issue",
 			Check:             codeClimateCheckName(&problem),
 			Description:       (&problem).Text,
-			RemediationPoints: 500,
+			RemediationPoints: 50000,
 			Categories:        []string{"Style"},
 			Location:          codeClimateLocation(&problem, relativePath),
 		}


### PR DESCRIPTION
* Minor cleanup
* Increase remediation points to 50,000: the previous value of 500 was far too low
* Have a default minimum confidence for issues to report, and allow it to be configured: the `golint` binary defaults to `0.8` for this. We weren't using any threshold, which was making our engine pretty noisy. Following the underlying's tool's default logic & allowing it to be configured in a similar way seems like a sane choice for us.