### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,21 @@
-FROM alpine:3.2
+FROM alpine:3.4
 
 MAINTAINER Code Climate <hello@codeclimate.com>
 
+WORKDIR /usr/src/app
+COPY codeclimate-golint.go /usr/src/app
+
+RUN apk --update add go git && \
+  export GOPATH=/tmp/go GOBIN=/usr/local/bin && \
+  go get -d . && \
+  go install codeclimate-golint.go && \
+  apk del go git && \
+  rm -rf "$GOPATH" rm /var/cache/apk/*
+
 WORKDIR /code
-
-COPY build/codeclimate-golint /usr/src/app/
-
 VOLUME /code
 
 RUN adduser -u 9000 -D app
 USER app
 
-CMD ["/usr/src/app/codeclimate-golint"]
+CMD ["/usr/local/bin/codeclimate-golint"]

--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ engines:
 
 ### Building
 
-In order to build the docker image, you first need to compile a binary for the container. To do that, first [install goxc]() and then run
-
 ```console
-goxc -bc="linux" -tasks-=go-install,go-vet,go-test,package,archive -d=. -arch=amd64 && \
-mv snapshot/linux_amd64/codeclimate-golint bin/codeclimate-golint && \
-rm -rf snapshot && \
 docker build -t codeclimate/codeclimate-golint .
 ```
 


### PR DESCRIPTION
* Updated base image to Alpine 3.4.
* `codeclimate-golint` binary is built inside the container. You don't need Go on your machine any more to build the image.
* Updated README to reflect the change. Also gocx is sort of deprecated since go is good at crosscompiling now. Moreover, it's not needed any more because source is compiled to image-native binary.

The image is slightly bigger than the current one (11.52 MiB vs 10.88 MiB).