### PR TITLE
Pass filepath to linter

### DIFF
--- a/codeclimate-golint.go
+++ b/codeclimate-golint.go
@@ -54,7 +54,7 @@ func lintFile(fullPath string, relativePath string, minConfidence float64) {
 		engine.PrintWarning(warning)
 	}
 
-	problems, err := linter.Lint("", code)
+	problems, err := linter.Lint(fullPath, code)
 	if err != nil {
 		warningDesc := fmt.Sprintf("Could not lint file (%s)", err)
 		warning := &engine.Warning{


### PR DESCRIPTION
Some of the checks are conditional based on the filepath. For example,
this check skips files that end in `_test.go`:
https://github.com/golang/lint/blob/206c0f020eba0f7fbcfbc467a5eb808037df2ed6/lint.go#L373-L375

Let's pass the filepath so the linter can make decisions such as that.

Close #10