### PR TITLE
Fix deploy

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,6 +12,7 @@ dependencies:
 test:
   override:
     - make image
+    - docker tag codeclimate/codeclimate-golint "$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM"
 
 deployment:
   registry:


### PR DESCRIPTION
My last change made the build green, but deploys still failed:
https://circleci.com/gh/codeclimate-community/codeclimate-golint/49

I think the issue is that the build wasn't tagged before it was pushed. This was in the `bin/build` script I removed.