### PR TITLE
Exit on error with proper error format

### DIFF
--- a/codeclimate-golint.go
+++ b/codeclimate-golint.go
@@ -41,29 +41,16 @@ func lintFile(fullPath string, relativePath string, minConfidence float64) {
 
 	code, err := ioutil.ReadFile(fullPath)
 	if err != nil {
-		warning := &engine.Warning{
-			Description: "Could not read file",
-			Location: &engine.Location{
-				Path: fullPath,
-				Lines: &engine.LinesOnlyPosition{
-					Begin: 1,
-					End:   1,
-				},
-			},
-		}
-		engine.PrintWarning(warning)
+		fmt.Fprintf(os.Stderr, "Could not read file: %v\n", fullPath)
+		fmt.Fprintf(os.Stderr, "Error %v\n", err)
+		os.Exit(1)
 	}
 
 	problems, err := linter.Lint(fullPath, code)
 	if err != nil {
-		warningDesc := fmt.Sprintf("Could not lint file (%s)", err)
-		warning := &engine.Warning{
-			Description: warningDesc,
-			Location: &engine.Location{
-				Path: fullPath,
-			},
-		}
-		engine.PrintWarning(warning)
+		fmt.Fprintf(os.Stderr, "Could not lint file: %v\n", fullPath)
+		fmt.Fprintf(os.Stderr, "Error %v\n", err)
+		os.Exit(1)
 	}
 
 	for _, problem := range problems {


### PR DESCRIPTION
For some reason this was printing errors in a JSON format similar to the issue format and not exiting, leading to the CLI trying to parse the error as an issue and erroring.

Before:
```
Starting analysis
Running golint: Failed

Analysis failed with the following output:
golint:stable produced invalid output: Category must be at least one of Bug Risk, Clarity,
Compatibility, Complexity, Duplication, Performance, Security, Style; Check name must be pr
esent; Location is not formatted correctly; Path must be relative to the project directory;
 Type must be 'issue' but was 'warning': `{"type"=>"warning", "description"=>"Could not lin
t file (/code/foo.go:1:1: expected 'package', found 'EOF')", "location"=>{"path"=>"/code/fo
o.go"}}`.
```

After:
```
Starting analysis
Running golint: Done!
error: (CC::Analyzer::Engine::EngineFailure) engine golint:stable failed with status 1 and stderr
Could not lint file: /code/foo.go
Error /code/foo.go:1:1: expected 'package', found 'EOF'
```

This makes the engine consistent with [gofmt](https://github.com/codeclimate-community/codeclimate-gofmt/blob/master/codeclimate-gofmt.go#L46-L50).