### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,13 +32,12 @@ jobs:
               circleci step halt
             fi
       - run: make image
-      - run: echo "$GCR_JSON_KEY" | docker login -u _json_key --password-stdin us.gcr.io
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
       - run:
-          name: Push image to GCR
+          name: Push image to Dockerhub
           command: |
-            docker tag codeclimate/codeclimate-golint \
-              us.gcr.io/code-climate/codeclimate-golint:b$CIRCLE_BUILD_NUM
-            docker push us.gcr.io/code-climate/codeclimate-golint:b$CIRCLE_BUILD_NUM
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
       - run: send_webhook
 
 workflows:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,12 @@
-.PHONY: update image
+.PHONY: update image release
 
 IMAGE_NAME ?= codeclimate/codeclimate-golint
+RELEASE_REGISTRY ?= codeclimate
+RELEASE_TAG ?= latest
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
+
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-golint:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-golint:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-golint
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .


### PR DESCRIPTION
Deprecate pushing of the image to GCR in favor of pushing to Dockerhub.